### PR TITLE
cuda-libraries-dev v13.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-2
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-2
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.1.0" %}
+{% set version = "13.1.1" %}
 
 package:
   name: cuda-libraries-dev
@@ -15,21 +15,21 @@ build:
 requirements:
   run:
     - cuda-cudart-dev 13.1.80
-    - cuda-cccl_{{ target_platform }} 13.1.78
-    - cuda-profiler-api 13.1.80
+    - cuda-cccl_{{ target_platform }} 13.1.115
+    - cuda-profiler-api 13.1.115
     - cuda-driver-dev 13.1.80    # [linux]
-    - cuda-nvrtc-dev 13.1.80
-    - cuda-opencl-dev 13.1.80    # [linux64 or win]
-    - libcublas-dev 13.2.0.9
-    - libcufft-dev 12.1.0.31
-    - libcufile-dev 1.16.0.49       # [linux]
-    - libcurand-dev 10.4.1.34
-    - libcusolver-dev 12.0.7.41
-    - libcusparse-dev 12.7.2.19
-    - libnpp-dev 13.0.2.21
-    - libnvfatbin-dev 13.1.80
-    - libnvjitlink-dev 13.1.80
-    - libnvjpeg-dev 13.0.2.28
+    - cuda-nvrtc-dev 13.1.115
+    - cuda-opencl-dev 13.1.115    # [linux64 or win]
+    - libcublas-dev 13.2.1.1
+    - libcufft-dev 12.1.0.78
+    - libcufile-dev 1.16.1.26       # [linux]
+    - libcurand-dev 10.4.1.81
+    - libcusolver-dev 12.0.9.81
+    - libcusparse-dev 12.7.3.1
+    - libnpp-dev 13.0.3.3
+    - libnvfatbin-dev 13.1.115
+    - libnvjitlink-dev 13.1.115
+    - libnvjpeg-dev 13.0.3.75
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.1.0" %}
 
 package:
   name: cuda-libraries-dev
@@ -14,22 +14,22 @@ build:
 
 requirements:
   run:
-    - cuda-cudart-dev 13.0.96
-    - cuda-cccl_{{ target_platform }} 13.0.85
-    - cuda-profiler-api 13.0.85
-    - cuda-driver-dev 13.0.96    # [linux]
-    - cuda-nvrtc-dev 13.0.88
-    - cuda-opencl-dev 13.0.85    # [linux64 or win]
-    - libcublas-dev 13.1.0.3
-    - libcufft-dev 12.0.0.61
-    - libcufile-dev 1.15.1.6       # [linux]
-    - libcurand-dev 10.4.0.35
-    - libcusolver-dev 12.0.4.66
-    - libcusparse-dev 12.6.3.3
-    - libnpp-dev 13.0.1.2
-    - libnvfatbin-dev 13.0.85
-    - libnvjitlink-dev 13.0.88
-    - libnvjpeg-dev 13.0.1.86
+    - cuda-cudart-dev 13.1.80
+    - cuda-cccl_{{ target_platform }} 13.1.78
+    - cuda-profiler-api 13.1.80
+    - cuda-driver-dev 13.1.80    # [linux]
+    - cuda-nvrtc-dev 13.1.80
+    - cuda-opencl-dev 13.1.80    # [linux64 or win]
+    - libcublas-dev 13.2.0.9
+    - libcufft-dev 12.1.0.31
+    - libcufile-dev 1.16.0.49       # [linux]
+    - libcurand-dev 10.4.1.34
+    - libcusolver-dev 12.0.7.41
+    - libcusparse-dev 12.7.2.19
+    - libnpp-dev 13.0.2.21
+    - libnvfatbin-dev 13.1.80
+    - libnvjitlink-dev 13.1.80
+    - libnvjpeg-dev 13.0.2.28
 
 test:
   commands:


### PR DESCRIPTION
cuda-libraries-dev 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12033](https://anaconda.atlassian.net/browse/PKG-12033) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release

### Notes

- PBP run: https://package-build.anaconda.com/v1/graph/e5c523b6-dc3f-413a-ad26-2858a27ae0cd


[PKG-12033]: https://anaconda.atlassian.net/browse/PKG-12033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ